### PR TITLE
Fix/stop old shooter log showing before new

### DIFF
--- a/bin/ark-sa-server.sh
+++ b/bin/ark-sa-server.sh
@@ -11,7 +11,16 @@ start_time=$(date +%s)
 echo "Ark Server - Starting at $start_time"
 
 main() {
+  handle_old_shooter_log
   start_server
+}
+
+handle_old_shooter_log() {
+  local shooter_log="${ARK_SERVER_DIR}/server/ShooterGame/Saved/Logs/ShooterGame.log"
+  if [[ -f "$shooter_log" ]]; then
+    echo "Ark Server - Deleting Old Shooter Logs"
+    rm "$shooter_log"
+  fi
 }
 
 start_server() {
@@ -53,12 +62,12 @@ start_server() {
 
   xvfb-run $proton_wine $server_exe "$cmd_args" $launch_flags &> $proton_wine_log &
 
-  log_file="${ARK_SERVER_DIR}/server/ShooterGame/Saved/Logs/ShooterGame.log"
-  timeout=300
+  local log_file="${ARK_SERVER_DIR}/server/ShooterGame/Saved/Logs/ShooterGame.log"
+  local timeout=300
 
   while [ ! -f "$log_file" ] && [ $timeout -gt 0 ]; do
     echo "Ark Server - Waiting for File $log_file to Exist"
-    sleep 1
+    sleep 5
     ((timeout--))
   done
 

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -9,14 +9,9 @@ childlogdir=/var/log/supervisor
 file=/var/run/supervisor.sock
 chmod=0770
 chown=ark-sa:ark-sa
-username=dummy
-password=dummy
-
 
 [supervisorctl]
 serverurl=unix:///var/run/supervisor.sock
-username=dummy
-password=dummy
 
 [rpcinterface:supervisor]
 supervisor.rpcinterface_factory=supervisor.rpcinterface:make_main_rpcinterface

--- a/tests/bin_scripts/ark-sa-server.sh
+++ b/tests/bin_scripts/ark-sa-server.sh
@@ -157,4 +157,14 @@ perform_test "ARK_MAX_PLAYERS Not Set - Default Player Count Is 70" \
               -c "/usr/local/bin/ark-sa-server.sh");
              echo $OUTPUT | grep -q "\-WinLiveMaxPlayers=70"'
 
+perform_test "Existing ShooterGame File Are Deleted To Avoid Premature Log Tail" \
+            'docker run --rm \
+            -e DRY_RUN=True \
+            --entrypoint bash \
+            johnnyknighten/ark-sa-server:latest \
+            -c "mkdir -p /ark-server/server/ShooterGame/Saved/Logs && \
+                touch /ark-server/server/ShooterGame/Saved/Logs/ShooterGame.log && \
+                /usr/local/bin/ark-sa-server.sh | grep -q "Deleting Old Shooter Logs"  \
+                test ! -f /ark-server/server/ShooterGame/Saved/Logs/ShooterGame.log"'
+
 log_failed_tests


### PR DESCRIPTION
## Description
Include a summary of the change and which issue is fixed. Also, include relevant motivation and context. List any dependencies that are required for this change.

Prevents old ShooterGame logs from being displayed before it is truncated and new log entries show.

## Issue/Ticket Number and Link (If Relevant)

No issue or ticket related to this.

## Type of Change
Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

Added "Existing ShooterGame File Are Deleted To Avoid Premature Log Tail" test to ark-sa-server tests.

## Checklist:
Before you submit your Pull Request, make sure you have done the following:

- [X] I have read the [CONTRIBUTING](CONTRIBUTING.md) document.
- [X] My code follows the code style of this project.
- [X] I have checked that my code does not duplicate any existing code (including PRs).
- [X] I have tested my code and made sure it works as expected.
- [ ] My change requires a change to the documentation, and I have updated the documentation accordingly.
- [X] I have provided a detailed description of my changes above.
- [ ] I have linked any related issues or PRs in my changes.

