### PR TITLE
fix: steamcmd force install dir before login

### DIFF
--- a/bin/ark-sa-updater.sh
+++ b/bin/ark-sa-updater.sh
@@ -28,12 +28,10 @@ download_and_update_ark_sa_server() {
     local app_update="+app_update 2430930 validate"
   fi
 
-  local install_dir="+force_install_dir $SERVER_DIR"
-
   if [[ "$DRY_RUN" = "True" ]]; then
-    echo "$DRY_RUN_MSG steamcmd +login anonymous \"$install_dir\" \"$app_update\" +quit"
+    echo "$DRY_RUN_MSG steamcmd +force_install_dir $SERVER_DIR +login anonymous $app_update +quit"
   else
-    steamcmd +login anonymous "$install_dir" "$app_update" +quit
+    steamcmd +force_install_dir "$SERVER_DIR" +login anonymous $app_update +quit
   fi
 }
 


### PR DESCRIPTION
Proposed fix for issue (#35).

Steamcmd started complaining about the order of arguments, specifically it wanted ```force_install_dir``` to come  before ```login```.

Updated ark-sa-updater.sh to accommodate this change.
